### PR TITLE
Implement print-registry command

### DIFF
--- a/src/Commands/CommandFactory.php
+++ b/src/Commands/CommandFactory.php
@@ -31,6 +31,8 @@ class CommandFactory
                 return $this->di->get(RegisterBuilt::class);
             case "download-artifact":
                 return $this->di->get(DownloadArtifact::class);
+            case "print-registry":
+                return $this->di->get(PrintRegistry::class);
             default:
                 throw new \Exception("Command '{$cmd}' not found");
         }

--- a/src/Commands/PrintRegistry.php
+++ b/src/Commands/PrintRegistry.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CITool\Commands;
+
+use CITool\Registry\Printer;
+use CITool\Service\CLIOutput;
+
+class PrintRegistry implements CommandInterface
+{
+    private $printer;
+    private $output;
+
+    public function __construct(Printer $printer, CLIOutput $output)
+    {
+        $this->printer = $printer;
+        $this->output = $output;
+    }
+
+    public function execute(): int
+    {
+        $this->output->printLn((string) $this->printer->printRegistry());
+        return 0;
+    }
+}

--- a/src/Registry/Printer.php
+++ b/src/Registry/Printer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CITool\Registry;
+
+use CITool\Util\Git;
+use CITool\Util\Shell;
+
+class Printer
+{
+    private const BLUE_ANSI_ESCAPE_CODE = '\033[0;34m';
+    private const NO_COLOR_ANSI_ESCAPE_CODE = '\033[0m';
+    private $store;
+    private $shell;
+    private $git;
+
+    public function __construct(Store $store, Shell $shell, Git $git)
+    {
+        $this->store = $store;
+        $this->shell = $shell;
+        $this->git = $git;
+    }
+
+    public function printRegistry(): ?string
+    {
+        $registry = $this->store->loadRegistry();
+        $currentHash = $this->git->getCurrentHash();
+
+        if ($registry->isHashRecorded($currentHash)) {
+            $cmd = sprintf(
+                "sed s/%s/$(printf \"%s%s%s\")/g %s",
+                $currentHash,
+                self::BLUE_ANSI_ESCAPE_CODE,
+                $currentHash,
+                self::NO_COLOR_ANSI_ESCAPE_CODE,
+                $this->store->getStorageFile()
+            );
+            return $this->shell->exec($cmd);
+        }
+
+        return $this->shell->exec("cat {$this->store->getStorageFile()}");
+    }
+}

--- a/src/Registry/Store.php
+++ b/src/Registry/Store.php
@@ -18,6 +18,11 @@ class Store
         }
     }
 
+    public function getStorageFile(): string
+    {
+        return $this->storageFile;
+    }
+
     public function loadRegistry(): Registry
     {
         return $this->serializer->deserialize(file_get_contents($this->storageFile));

--- a/test/Integration/Commands/PrintRegistryTest.php
+++ b/test/Integration/Commands/PrintRegistryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use CITool\Commands\CommandFactory;
+use CITool\Registry\Record;
+use CITool\Registry\Store;
+use CITool\Test\Integration\AbstractTest;
+
+class PrintRegistryTest extends AbstractTest
+{
+    /**
+     * @var CommandFactory
+     */
+    private $cmdFactory;
+    /**
+     * @var Store
+     */
+    private $store;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $c = $this->builder->build();
+        $this->store = $c->get(Store::class);
+        $this->cmdFactory = $c->get(CommandFactory::class);
+    }
+
+    public function testCurrentHashIsHighlightedWhenRegistryIsPrinted()
+    {
+        $registry = $this->store->loadRegistry();
+        $registry->register(new Record("1234", "98"));
+        $registry->register(new Record("9876", "12"));
+        $this->store->saveRegistry($registry);
+
+        $this->shellMock->method("exec")
+            ->withConsecutive(
+                ["git diff $(git rev-list --max-parents=0 HEAD)..HEAD | shasum | awk '{print $1}'"],
+                ["sed s/9876/$(printf \"\\033[0;34m9876\\033[0m\")/g {$this->store->getStorageFile()}"]
+            )->willReturnOnConsecutiveCalls("9876", "Test output");
+
+        $this->expectConsoleOutput("Test output", $this->once());
+
+        $cmd = $this->cmdFactory->create("print-registry");
+        $status = $cmd->execute();
+        $this->assertEquals(0, $status);
+    }
+
+    public function testNothingIsHighlightedWhenCurrentHashIsNotInTheRegistry()
+    {
+        $registry = $this->store->loadRegistry();
+        $registry->register(new Record("1234", "98"));
+        $this->store->saveRegistry($registry);
+
+        $this->shellMock->method("exec")
+            ->withConsecutive(
+                ["git diff $(git rev-list --max-parents=0 HEAD)..HEAD | shasum | awk '{print $1}'"],
+                ["cat {$this->store->getStorageFile()}"]
+            )->willReturnOnConsecutiveCalls("9999", "Test output");
+        $this->expectConsoleOutput("Test output", $this->once());
+
+        $cmd = $this->cmdFactory->create("print-registry");
+        $status = $cmd->execute();
+        $this->assertEquals(0, $status);
+    }
+}


### PR DESCRIPTION
Added a `print-registry` command which will make it easier to debug the tool's decisions. 
It also highlights the current hash in blue so that it is possible to know what record in the registry the tool is currently working with. See screenshot below of how it looks:

![Screenshot 2020-07-06 at 16 57 36](https://user-images.githubusercontent.com/8201815/86618038-1d99f600-bfb0-11ea-99ee-7fb708df77d1.png)
